### PR TITLE
[Fix] Weapon, Trap 어빌리티 버그 수정

### DIFF
--- a/Content/AbilitySystem/Data/AbilitySet_CombatCop.uasset
+++ b/Content/AbilitySystem/Data/AbilitySet_CombatCop.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e649d3f2a0b99be5d012797904c6f5693b2f801fb193f00a383acc503347943
+size 3165

--- a/Content/AbilitySystem/Data/AbilitySet_CombatRobber.uasset
+++ b/Content/AbilitySystem/Data/AbilitySet_CombatRobber.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1f9a3cf0d702f7966a240bb01a7189e6a7a3083e59a57622cc24763effe796
+size 1983

--- a/Content/Characters/Data/PawnData_Cop.uasset
+++ b/Content/Characters/Data/PawnData_Cop.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:33b5bf458e4fe1fefc57d87bd626d8e4b57b1f4b409138f958623566cffb65ae
-size 2200
+oid sha256:8a462ff2358acdd0e0ce2892a5eff1b2314b1dde8ed8e2e54684c411ba9997d0
+size 2188

--- a/Content/Characters/Data/PawnData_Robber.uasset
+++ b/Content/Characters/Data/PawnData_Robber.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1becac89cfe35a0fbd6bfd42432feea5e1bffdee3df2470be574a9b7e2a449cd
-size 2239
+oid sha256:3b19228727781554e6285117918d235db1970381e1d8d9f6276fda936f097aeb
+size 2233

--- a/Content/Items/BP_Baton.uasset
+++ b/Content/Items/BP_Baton.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94edd8af077901c80cbb6b7ba08c2a8ef22ca7a682c77e77562e60ff4ef5ac01
-size 30160
+oid sha256:d42d3225a810b6095a85fd730710c37738e5ec9f89796fd95b1f6004dd357fd6
+size 31596

--- a/Content/Items/BP_DamageTrap.uasset
+++ b/Content/Items/BP_DamageTrap.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ea4707aae4a09ba3c8658d1d63c64e0354450dce87ed37586dc5e46be7e671e
-size 33199
+oid sha256:632b131f708fced24fa5b65d580e92be65646197a32ccd3e271c7cf785bd78cd
+size 34617

--- a/Content/Items/BP_FreezeTrap.uasset
+++ b/Content/Items/BP_FreezeTrap.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b304f170756fcb395abaa1543bcbf1dd546e853f5543543167e2287f8f4df9d
-size 33199
+oid sha256:c14860516cef0dd63026cad6da8a596427eb572c38a8c0808873f284b8329828
+size 34676

--- a/Content/Items/BP_SlowTrap.uasset
+++ b/Content/Items/BP_SlowTrap.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e88a26685d32aa569d6d1488674df83d0c0bb5788d5c07ce402ab9a2c93e710a
-size 33130
+oid sha256:17c8ff62285a22f9f81ad2849bc305f9f5bb905709f34b9b117221b4100936d3
+size 34613

--- a/Source/CatchMeIfYouCan/AbilitySystem/Abilities/Combat/GA_PlaceTrap.cpp
+++ b/Source/CatchMeIfYouCan/AbilitySystem/Abilities/Combat/GA_PlaceTrap.cpp
@@ -24,7 +24,9 @@ UGA_PlaceTrap::UGA_PlaceTrap()
     FGameplayTagContainer BlockedTags;
 	BlockedTags.AddTag(CYGameplayTags::State_Stunned);
 	BlockedTags.AddTag(CYGameplayTags::State_Captured);
-	BlockedTags.AddTag(CYGameplayTags::State_Jail);  
+	BlockedTags.AddTag(CYGameplayTags::State_Jail);
+	BlockedTags.AddTag(CYGameplayTags::Ability_Combat_PlaceTrap);
+	BlockedTags.AddTag(CYGameplayTags::State_Combat_Attacking);
     ActivationBlockedTags = BlockedTags;
     
     // 쿨다운 GE 클래스 설정
@@ -45,13 +47,12 @@ void UGA_PlaceTrap::ActivateAbility(const FGameplayAbilitySpecHandle Handle,
         return;
     }
 
-	// 쿨다운과 코스트 체크 및 적용
-    if (!CommitAbility(Handle, ActorInfo, ActivationInfo))
-    {
-        UE_LOG(LogTemp, Warning, TEXT("Trap placement on cooldown"));
-        EndAbility(Handle, ActorInfo, ActivationInfo, true, false);
-        return;
-    }
+	if (IsOnCooldown(ActorInfo))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Trap placement on cooldown"));
+		EndAbility(Handle, ActorInfo, ActivationInfo, true, false);
+		return;
+	}
 
 	// 소스 오브젝트(들고 있는 트랩)에서 트랩 아이템 가져오기
     ACYTrapBase* TrapItem = GetTrapItemFromSource();
@@ -66,6 +67,14 @@ void UGA_PlaceTrap::ActivateAbility(const FGameplayAbilitySpecHandle Handle,
             return;
         }
     }
+
+	// // 수량 체크
+	// if (TrapItem->ItemCount <= 0)
+	// {
+	// 	UE_LOG(LogTemp, Warning, TEXT("Trap item count is 0 or less"));
+	// 	EndAbility(Handle, ActorInfo, ActivationInfo, true, true);
+	// 	return;
+	// }
 
 	// 정보 캐시 (몽타주 완료 후 사용)
 	CachedHandle = Handle;
@@ -108,9 +117,35 @@ void UGA_PlaceTrap::OnPlaceTrapMontageCompleted()
 	
 	// 실제 트랩 설치 로직 실행
 	PerformTrapPlacement();
+
+	// 쿨다운 적용
+	ApplyTrapCooldown(CachedHandle, CachedActorInfo, CachedActivationInfo);
 	
 	// 어빌리티 종료
 	EndAbility(CachedHandle, CachedActorInfo, CachedActivationInfo, true, false);
+}
+
+bool UGA_PlaceTrap::IsOnCooldown(const FGameplayAbilityActorInfo* ActorInfo) const
+{
+	return ActorInfo->AbilitySystemComponent->HasMatchingGameplayTag(CYGameplayTags::Cooldown_Combat_TrapPlace);
+}
+
+void UGA_PlaceTrap::ApplyTrapCooldown(const FGameplayAbilitySpecHandle Handle, 
+	const FGameplayAbilityActorInfo* ActorInfo, 
+	const FGameplayAbilityActivationInfo ActivationInfo)
+{
+	FGameplayEffectSpecHandle CooldownSpec = MakeOutgoingGameplayEffectSpec(UGE_TrapPlaceCooldown::StaticClass(), 1);
+	if (CooldownSpec.IsValid())
+	{
+		FGameplayTag CooldownTag = CYGameplayTags::Cooldown_Combat_TrapPlace;
+		if (CooldownTag.IsValid())
+		{
+			CooldownSpec.Data->DynamicGrantedTags.AddTag(CooldownTag);
+		}
+
+		ApplyGameplayEffectSpecToOwner(Handle, ActorInfo, ActivationInfo, CooldownSpec);
+		UE_LOG(LogTemp, Warning, TEXT("Trap cooldown applied"));
+	}
 }
 
 void UGA_PlaceTrap::PerformTrapPlacement()
@@ -280,6 +315,12 @@ void UGA_PlaceTrap::ConsumeItemFromInventory(ACYItemBase* Item)
     UCYInventoryComponent* InventoryComp = OwnerActor->FindComponentByClass<UCYInventoryComponent>();
     if (!InventoryComp) return;
 
+	if (Item->ItemCount <= 0)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Item count already 0, skipping consume"));
+		return;
+	}
+
     // 아이템 수량 감소
     Item->ItemCount--;
     
@@ -292,6 +333,14 @@ void UGA_PlaceTrap::ConsumeItemFromInventory(ACYItemBase* Item)
             {
                 InventoryComp->ItemSlots[i] = nullptr;
                 InventoryComp->OnInventoryChanged.Broadcast(i + 4, nullptr); // 4~9번 키
+
+            	// CurrentHeldItem이 소진된 아이템이면 null로 설정
+            	if (InventoryComp->CurrentHeldItem == Item)
+            	{
+            		InventoryComp->CurrentHeldItem = nullptr;
+            		InventoryComp->OnHeldItemChanged.Broadcast(Item, nullptr);
+            	}
+            	
                 Item->Destroy();
                 break;
             }

--- a/Source/CatchMeIfYouCan/AbilitySystem/Abilities/Combat/GA_PlaceTrap.h
+++ b/Source/CatchMeIfYouCan/AbilitySystem/Abilities/Combat/GA_PlaceTrap.h
@@ -44,6 +44,13 @@ private:
 	// 사용한 트랩 아이템을 인벤토리에서 소모하기
 	void ConsumeItemFromInventory(ACYItemBase* Item);
 
+	// 쿨타운 상태 체크
+	bool IsOnCooldown(const FGameplayAbilityActorInfo* ActorInfo) const;
+	// 쿨타운 적용
+	void ApplyTrapCooldown(const FGameplayAbilitySpecHandle Handle, 
+		const FGameplayAbilityActorInfo* ActorInfo, 
+		const FGameplayAbilityActivationInfo ActivationInfo);
+
 private:
 	// 어빌리티 정보 캐시
 	FGameplayAbilitySpecHandle CachedHandle;

--- a/Source/CatchMeIfYouCan/AbilitySystem/Abilities/Combat/GA_WeaponAttack.cpp
+++ b/Source/CatchMeIfYouCan/AbilitySystem/Abilities/Combat/GA_WeaponAttack.cpp
@@ -3,10 +3,12 @@
 #include "AbilitySystemComponent.h"
 #include "AbilitySystem/CYCombatGameplayTags.h"
 #include "AbilitySystem/Effects/CYCombatGameplayEffects.h"
+#include "Character/CYPlayerCharacter.h"
 #include "Components/Items/CYWeaponComponent.h"
 #include "Engine/Engine.h"
 #include "GameFramework/Character.h"
 #include "Items/CYWeaponBase.h"
+#include "Player/CYPlayerState.h"
 
 UGA_WeaponAttack::UGA_WeaponAttack()
 {
@@ -29,7 +31,9 @@ UGA_WeaponAttack::UGA_WeaponAttack()
 	FGameplayTagContainer BlockedTags;
 	BlockedTags.AddTag(CYGameplayTags::State_Stunned);
 	BlockedTags.AddTag(CYGameplayTags::State_Captured);
-	BlockedTags.AddTag(CYGameplayTags::State_Jail); 
+	BlockedTags.AddTag(CYGameplayTags::State_Jail);
+	BlockedTags.AddTag(CYGameplayTags::State_Combat_Attacking);
+	BlockedTags.AddTag(CYGameplayTags::Ability_Combat_PlaceTrap);
 	ActivationBlockedTags = BlockedTags;
 }
 
@@ -167,6 +171,18 @@ void UGA_WeaponAttack::ProcessHitTarget(const FHitResult& HitResult)
 {
     AActor* Target = HitResult.GetActor();
     if (!Target) return;
+
+	// 팀 체크 Robber만 공격받도록
+	if (ACYPlayerCharacter* TargetCharacter = Cast<ACYPlayerCharacter>(Target))
+	{
+		if (ACYPlayerState* TargetPS = TargetCharacter->GetPlayerState<ACYPlayerState>())
+		{
+			if (TargetPS->GetTeamRole() != ECYTeamRole::Robber)
+			{
+				return;
+			}
+		}
+	}
 
     UAbilitySystemComponent* TargetASC = UAbilitySystemBlueprintLibrary::GetAbilitySystemComponent(Target);
     if (!TargetASC) 

--- a/Source/CatchMeIfYouCan/Character/CYPlayerCharacter.cpp
+++ b/Source/CatchMeIfYouCan/Character/CYPlayerCharacter.cpp
@@ -205,6 +205,11 @@ void ACYPlayerCharacter::Input_Attack(const FInputActionValue& InputActionValue)
 	// 현재 들고 있는 아이템이 있으면 아이템 사용
 	if (InventoryComponent && InventoryComponent->CurrentHeldItem)
 	{
+		if (InventoryComponent->CurrentHeldItem->ItemCount <= 0)
+		{
+			return;
+		}
+		
 		FText ItemName = InventoryComponent->CurrentHeldItem->ItemName;
 		bool bUsedItem = InventoryComponent->UseHeldItem();
 		

--- a/Source/CatchMeIfYouCan/Components/Items/CYInventoryComponent.cpp
+++ b/Source/CatchMeIfYouCan/Components/Items/CYInventoryComponent.cpp
@@ -36,6 +36,7 @@ void UCYInventoryComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>
     DOREPLIFETIME(UCYInventoryComponent, ItemSlots);
     DOREPLIFETIME(UCYInventoryComponent, CurrentHeldItem);
     DOREPLIFETIME(UCYInventoryComponent, bIsProcessingUse);
+	DOREPLIFETIME(UCYInventoryComponent, bIsUsingTrap); 
 }
 
 bool UCYInventoryComponent::AddItem(ACYItemBase* Item)
@@ -238,47 +239,71 @@ bool UCYInventoryComponent::UseHeldItem()
         }
         return false;
     }
+
+	// 수량이 0 이하면 사용하지 않음
+	if (CurrentHeldItem->ItemCount <= 0)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Item count is 0 or less, cannot use"));
+		return false;
+	}
     
+	// 트랩 사용 중복 방지
+	if (CurrentHeldItem->ItemType == EItemType::Trap)
+	{
+		if (bIsUsingTrap)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("Already using trap, ignoring duplicate call"));
+			return false;
+		}
+		bIsUsingTrap = true;
+        
+		// 0.5초 후 플래그 해제 (트랩 설치 완료 시간보다 짧게)
+		GetWorld()->GetTimerManager().SetTimer(
+			TrapUseCooldownTimer,
+			[this]() { bIsUsingTrap = false; },
+			0.5f,
+			false
+		);
+	}
+    
+	FText ItemName = CurrentHeldItem->ItemName;
     bool bSuccess = CurrentHeldItem->UseItem(Cast<ACYPlayerCharacter>(GetOwner()));
     
-    if (bSuccess && CurrentHeldItem->ItemType == EItemType::Trap)
-    {
-        // 트랩 사용 시 수량 감소
-        CurrentHeldItem->ItemCount--;
+	if (bSuccess && CurrentHeldItem->ItemType == EItemType::Consumable)
+	{
+		CurrentHeldItem->ItemCount--;
         
-        if (CurrentHeldItem->ItemCount <= 0)
-        {
-            // 아이템이 모두 소모되면 슬롯에서 제거하고 손에서도 해제
-            for (int32 i = 0; i < ItemSlots.Num(); ++i)
-            {
-                if (ItemSlots[i] == CurrentHeldItem)
-                {
-                    ItemSlots[i] = nullptr;
-                    OnInventoryChanged.Broadcast(i + 4, nullptr);
-                    break;
-                }
-            }
+		if (CurrentHeldItem->ItemCount <= 0)
+		{
+			for (int32 i = 0; i < ItemSlots.Num(); ++i)
+			{
+				if (ItemSlots[i] == CurrentHeldItem)
+				{
+					ItemSlots[i] = nullptr;
+					OnInventoryChanged.Broadcast(i + 4, nullptr);
+					break;
+				}
+			}
             
-            DetachItemFromHand(CurrentHeldItem);
-            ACYItemBase* OldHeldItem = CurrentHeldItem;
-            CurrentHeldItem = nullptr;
-            OnHeldItemChanged.Broadcast(OldHeldItem, nullptr);
+			DetachItemFromHand(CurrentHeldItem);
+			ACYItemBase* OldHeldItem = CurrentHeldItem;
+			CurrentHeldItem = nullptr;
+			OnHeldItemChanged.Broadcast(OldHeldItem, nullptr);
             
-            OldHeldItem->Destroy();
-        }
-        else
-        {
-            // 수량만 감소한 경우 인벤토리 업데이트
-            for (int32 i = 0; i < ItemSlots.Num(); ++i)
-            {
-                if (ItemSlots[i] == CurrentHeldItem)
-                {
-                    OnInventoryChanged.Broadcast(i + 4, CurrentHeldItem);
-                    break;
-                }
-            }
-        }
-    }
+			OldHeldItem->Destroy();
+		}
+		else
+		{
+			for (int32 i = 0; i < ItemSlots.Num(); ++i)
+			{
+				if (ItemSlots[i] == CurrentHeldItem)
+				{
+					OnInventoryChanged.Broadcast(i + 4, CurrentHeldItem);
+					break;
+				}
+			}
+		}
+	}
     
     return bSuccess;
 }

--- a/Source/CatchMeIfYouCan/Components/Items/CYInventoryComponent.h
+++ b/Source/CatchMeIfYouCan/Components/Items/CYInventoryComponent.h
@@ -114,4 +114,9 @@ private:
     // 중복 실행 방지
     UPROPERTY(Replicated)
     bool bIsProcessingUse = false;
+
+	// 트랩 사용 중복 방지
+	UPROPERTY(Replicated)
+	bool bIsUsingTrap = false;
+	FTimerHandle TrapUseCooldownTimer; 
 };

--- a/Source/CatchMeIfYouCan/Components/Items/CYItemInteractionComponent.cpp
+++ b/Source/CatchMeIfYouCan/Components/Items/CYItemInteractionComponent.cpp
@@ -52,6 +52,16 @@ void UCYItemInteractionComponent::InteractWithNearbyItem()
 void UCYItemInteractionComponent::ServerPickupItem_Implementation(ACYItemBase* Item)
 {
     if (!Item || !GetOwner()->HasAuthority() || Item->bIsPickedUp) return;
+
+	ACYPlayerCharacter* Character = Cast<ACYPlayerCharacter>(GetOwner());
+	if (!Character) return;
+    
+	// 팀 체크
+	if (!Item->CanBePickedUpBy(Character))
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Cannot pickup item: Team restriction"));
+		return;
+	}
     
     UCYInventoryComponent* InventoryComp = GetOwner()->FindComponentByClass<UCYInventoryComponent>();
     if (!InventoryComp)
@@ -77,6 +87,9 @@ void UCYItemInteractionComponent::ServerPickupItem_Implementation(ACYItemBase* I
 void UCYItemInteractionComponent::CheckForNearbyItems()
 {
     if (!GetOwner()) return;
+
+	ACYPlayerCharacter* Character = Cast<ACYPlayerCharacter>(GetOwner());
+	if (!Character) return;
     
     FVector PlayerLocation = GetOwner()->GetActorLocation();
     ACYItemBase* ClosestItem = nullptr;
@@ -90,6 +103,9 @@ void UCYItemInteractionComponent::CheckForNearbyItems()
     {
         ACYItemBase* Item = Cast<ACYItemBase>(Actor);
         if (!Item || Item->bIsPickedUp) continue;
+
+    	// 팀 체크
+    	if (!Item->CanBePickedUpBy(Character)) continue;
         
         // 트랩의 경우 맵에 배치된 것만 픽업 가능
         if (ACYTrapBase* Trap = Cast<ACYTrapBase>(Item))

--- a/Source/CatchMeIfYouCan/Items/CYItemBase.cpp
+++ b/Source/CatchMeIfYouCan/Items/CYItemBase.cpp
@@ -1,5 +1,6 @@
 #include "Items/CYItemBase.h"
 #include "Character/CYPlayerCharacter.h"
+#include "Player/CYPlayerState.h"
 #include "Components/StaticMeshComponent.h"
 #include "Components/SphereComponent.h"
 #include "Net/UnrealNetwork.h"
@@ -34,6 +35,10 @@ ACYItemBase::ACYItemBase()
     bIsPickedUp = false;
     ItemCount = 1;
     MaxStackCount = 10;
+
+	// 기본값: 모든 팀이 픽업 가능
+	AllowedTeams.Add(ECYTeamRole::Cop);
+	AllowedTeams.Add(ECYTeamRole::Robber);
 }
 
 void ACYItemBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
@@ -136,4 +141,31 @@ void ACYItemBase::OnSphereEndOverlap(UPrimitiveComponent* OverlappedComponent, A
         // UI 힌트 숨기기
         UE_LOG(LogTemp, Log, TEXT("Player left item area: %s"), *ItemName.ToString());
     }
+}
+
+bool ACYItemBase::CanBePickedUpBy(ACYPlayerCharacter* Character) const
+{
+	if (!Character) return false;
+    
+	// AllowedTeams가 비어있으면 모두 픽업 가능
+	if (AllowedTeams.Num() == 0) return true;
+    
+	// PlayerState에서 팀 확인
+	ACYPlayerState* PS = Character->GetPlayerState<ACYPlayerState>();
+	if (!PS) return false;
+    
+	ECYTeamRole CharacterTeam = PS->GetTeamRole();
+    
+	// AllowedTeams에 캐릭터 팀이 포함되어 있는지 확인
+	bool bCanPickup = AllowedTeams.Contains(CharacterTeam);
+    
+	if (!bCanPickup)
+	{
+		UE_LOG(LogTemp, Log, TEXT("Character team %s cannot pickup item %s (Allowed teams: %d)"), 
+			CharacterTeam == ECYTeamRole::Cop ? TEXT("Cop") : TEXT("Robber"),
+			*ItemName.ToString(),
+			AllowedTeams.Num());
+	}
+    
+	return bCanPickup;
 }

--- a/Source/CatchMeIfYouCan/Items/CYItemBase.h
+++ b/Source/CatchMeIfYouCan/Items/CYItemBase.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "CYTypes/CYTeamType.h"
 #include "CYItemBase.generated.h"
 
 class ACYPlayerCharacter;
@@ -35,6 +36,9 @@ public:
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Item")
     int32 MaxStackCount = 10;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Item|Team", meta = (Bitmask, BitmaskEnum = "ECYTeamRole"))
+	TArray<ECYTeamRole> AllowedTeams;
+
     // 현재 수량 (네트워크 동기화)
     UPROPERTY(ReplicatedUsing = OnRep_ItemCount, BlueprintReadOnly, Category = "Item")
     int32 ItemCount = 1;
@@ -59,6 +63,9 @@ public:
 
     UFUNCTION(BlueprintCallable, Category = "Item")
     bool CanStackWith(ACYItemBase* OtherItem) const;
+
+	UFUNCTION(BlueprintCallable, Category = "Item|Team")
+	bool CanBePickedUpBy(ACYPlayerCharacter* Character) const;
 
 protected:
     virtual void BeginPlay() override;

--- a/Source/CatchMeIfYouCan/Items/Traps/CYTrapBase.cpp
+++ b/Source/CatchMeIfYouCan/Items/Traps/CYTrapBase.cpp
@@ -32,6 +32,7 @@ void ACYTrapBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifet
     
     DOREPLIFETIME(ACYTrapBase, TrapState);
     DOREPLIFETIME(ACYTrapBase, bIsArmed);
+	DOREPLIFETIME(ACYTrapBase, bHasTriggered);
 }
 
 void ACYTrapBase::BeginPlay()
@@ -127,6 +128,12 @@ void ACYTrapBase::OnTrapSphereOverlap(UPrimitiveComponent* OverlappedComponent, 
     UPrimitiveComponent* OtherComp, int32 OtherBodyIndex,
     bool bFromSweep, const FHitResult& SweepResult)
 {
+	// 이미 트리거됐으면 무시
+	if (bHasTriggered)
+	{
+		return;
+	}
+	
     // 트랩이 활성화 상태가 아니면 무시
     if (TrapState != ETrapState::PlayerPlaced || !bIsArmed || !HasAuthority()) return;
     
@@ -144,7 +151,9 @@ void ACYTrapBase::OnTrapSphereOverlap(UPrimitiveComponent* OverlappedComponent, 
 			return;
 		}
 	}
-    
+
+	// 트리거 플래그 설정
+	bHasTriggered = true;
     OnTrapTriggered(Target);
 }
 

--- a/Source/CatchMeIfYouCan/Items/Traps/CYTrapBase.h
+++ b/Source/CatchMeIfYouCan/Items/Traps/CYTrapBase.h
@@ -39,6 +39,9 @@ public:
     UPROPERTY(ReplicatedUsing = OnRep_IsArmed, BlueprintReadOnly, Category = "Trap")
     bool bIsArmed = false;
 
+	UPROPERTY(Replicated)
+	bool bHasTriggered = false;
+
     // 트랩 설정
     UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Trap")
     float TriggerRadius = 100.0f;


### PR DESCRIPTION
도둑 role을 가진 플레이어만 Weapon에 의해 데미지 받도록 수정
공격키를 여러번 누를 때 데미지가 중첩돼서 들어가는 버그 수정
트랩 아이템을 사용했을 때 인벤토리에서 해당 트랩 아이템의 수량이 2개씩 소모되는 버그 수정 트랩 아이템을 사용할 때 빠르게 여러번 클릭했을 때 지정된 수량보다 더 많은 트랩이 설치되는 버그 수정 인벤토리 인덱스에서 해당 아이템의 수량이 모두 소모될 때 자동으로 다음 인덱스로 넘어가는 버그 수정 트랩 설치 쿨타임 관리 수동으로 변경
아이템 블루프린트에서 원하는 팀롤(경찰, 도둑)만 획득 가능하도록 설정